### PR TITLE
DIRSTUDIO-861 - Strings.toLowerCase() shouldn't be used for attribute values.

### DIFF
--- a/plugins/ldapbrowser.core/src/main/java/org/apache/directory/studio/ldapbrowser/core/utils/Utils.java
+++ b/plugins/ldapbrowser.core/src/main/java/org/apache/directory/studio/ldapbrowser/core/utils/Utils.java
@@ -130,7 +130,7 @@ public class Utils
         String oid = schema != null ? schema.getAttributeTypeDescription( ava.getNormType() ).getOid() : ava
             .getNormType();
         return Strings.toLowerCase( Strings.trim( oid ) )
-            + "=" + Strings.toLowerCase( Strings.trim( ava.getValue().getString() ) ); //$NON-NLS-1$
+            + "=" + Strings.trim( ava.getValue().getString() ).toLowerCase(); //$NON-NLS-1$
     }
 
 


### PR DESCRIPTION
Update `plugins/ldapbrowser.core/src/main/java/org/apache/directory/studio/ldapbrowser/core/utils/Utils.java`

Resolve DIRSTUDIO-861. optimized Strings.toLowerCase() shouldn't be used for attribute values.

regards
Grzegorz Grzybek
