### PR TITLE
remove references to obsolete babel 0.15

### DIFF
--- a/eclipse-trgt-platform/template/org.apache.directory.studio.eclipse-trgt-platform.template
+++ b/eclipse-trgt-platform/template/org.apache.directory.studio.eclipse-trgt-platform.template
@@ -139,12 +139,6 @@
       <repository location="http://download.eclipse.org/technology/swtbot/releases/3.0.0/"/>
     </location>
 
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.babel.nls_eclipse_de.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.babel.nls_eclipse_fr.feature.group" version="0.0.0"/>
-      <repository location="http://archive.eclipse.org/technology/babel/update-site/R0.15.1/oxygen"/>
-    </location>
-
   </locations>
 
   <launcherArgs>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -37,7 +37,6 @@
     <module>rcp.feature</module>
     <module>schemaeditor.feature</module>
     <module>openldap.feature</module>
-    <module>nls.feature</module>
   </modules>
   
   <build>

--- a/p2repositories/product/category.xml
+++ b/p2repositories/product/category.xml
@@ -19,7 +19,6 @@
    <feature url="features/org.apache.directory.studio.rcp.feature_2.0.0.qualifier.jar" id="org.apache.directory.studio.rcp.feature" version="2.0.0.qualifier">
       <category name="org.apache.directory.studio.product"/>
    </feature>
-   <feature url="features/org.apache.directory.studio.nls.feature_2.0.0.qualifier.jar" id="org.apache.directory.studio.nls.feature" version="2.0.0.qualifier">
       <category name="org.apache.directory.studio.product"/>
    </feature>
    <bundle id="org.apache.directory.studio.slf4j-eclipselog" version="2.0.0.qualifier">

--- a/product/org.apache.directory.studio.product
+++ b/product/org.apache.directory.studio.product
@@ -243,7 +243,6 @@ http://www.apache.org/licenses/
 
    <features>
       <feature id="org.apache.directory.studio.rcp.feature"/>
-      <feature id="org.apache.directory.studio.nls.feature"/>
       <feature id="org.apache.directory.studio.apacheds.feature"/>
       <feature id="org.apache.directory.studio.ldapbrowser.feature"/>
       <feature id="org.apache.directory.studio.ldifeditor.feature"/>


### PR DESCRIPTION
Latest babel version is 0.19, build spends a lot of time looking for the same files that do not exist on the eclipse archive. it's building without them anyway so should remove references to speed up the build process. It's does not appear to be a simple matter of just changing version 0.15 to 0.19.