### PR TITLE
Fix https://issues.apache.org/jira/browse/DIRSTUDIO-933

### DIFF
--- a/plugins/ldapbrowser.common/src/main/java/org/apache/directory/studio/ldapbrowser/common/widgets/ListContentProposalProvider.java
+++ b/plugins/ldapbrowser.common/src/main/java/org/apache/directory/studio/ldapbrowser/common/widgets/ListContentProposalProvider.java
@@ -124,7 +124,7 @@ public class ListContentProposalProvider implements IContentProposalProvider
         }
         else
         {
-            this.proposals = newProposals;
+            this.proposals = new ArrayList<String>( newProposals );
         }
     }
 


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/DIRSTUDIO-933 by decoupling the drop down history from the list used by the proposal provider.