### PR TITLE
DIRSTUDIO-1298: Fix the Postal Address value editor en-/decoding.

### DIFF
--- a/plugins/ldapbrowser.core/src/main/java/org/apache/directory/studio/ldapbrowser/core/utils/Utils.java
+++ b/plugins/ldapbrowser.core/src/main/java/org/apache/directory/studio/ldapbrowser/core/utils/Utils.java
@@ -684,4 +684,19 @@ public class Utils
             .replace( "\\5C", "\\" ) //$NON-NLS-1$ //$NON-NLS-2$
             .replace( "\\5c", "\\" ); //$NON-NLS-1$ //$NON-NLS-2$
     }
+
+
+    /**
+     * Encodes the RFC 4517 Postal Address syntax.
+     *
+     * @param input the string to encode
+     * @param separator the separator used between address lines
+     * @return the encoded string
+     */
+    public static String encodePostalAddress( String input, String separator )
+    {
+        return input.replace( "\\", "\\5C" ) //$NON-NLS-1$ //$NON-NLS-2$
+            .replace( "$", "\\24" ) //$NON-NLS-1$ //$NON-NLS-2$
+            .replace( separator, "$" ); //$NON-NLS-1$
+    }
 }

--- a/plugins/ldapbrowser.core/src/test/java/org/apache/directory/studio/ldapbrowser/core/utils/UtilsTest.java
+++ b/plugins/ldapbrowser.core/src/test/java/org/apache/directory/studio/ldapbrowser/core/utils/UtilsTest.java
@@ -30,6 +30,7 @@ public class UtilsTest
     public void testPostalAddressTrivial()
     {
         assertEquals( "abc", Utils.decodePostalAddress( "abc", "!" ) );
+        assertEquals( "abc", Utils.encodePostalAddress( "abc", "!" ) );
     }
 
 
@@ -40,6 +41,10 @@ public class UtilsTest
         assertEquals( "$", Utils.decodePostalAddress( "\\24", "!" ) );
         assertEquals( "\\", Utils.decodePostalAddress( "\\5C", "!" ) );
         assertEquals( "\\", Utils.decodePostalAddress( "\\5c", "!" ) );
+
+        assertEquals( "$", Utils.encodePostalAddress( "!", "!" ) );
+        assertEquals( "\\24", Utils.encodePostalAddress( "$", "!" ) );
+        assertEquals( "\\5C", Utils.encodePostalAddress( "\\", "!" ) );
     }
 
 
@@ -50,5 +55,10 @@ public class UtilsTest
             Utils.decodePostalAddress( "1234 Main St.$Anytown, CA 12345$USA", "\n" ) );
         assertEquals( "$1,000,000 Sweepstakes\nPO Box 1000000\nAnytown, CA 12345\nUSA",
             Utils.decodePostalAddress( "\\241,000,000 Sweepstakes$PO Box 1000000$Anytown, CA 12345$USA", "\n" ) );
+
+        assertEquals( "1234 Main St.$Anytown, CA 12345$USA",
+            Utils.encodePostalAddress( "1234 Main St.\nAnytown, CA 12345\nUSA", "\n" ) );
+        assertEquals( "\\241,000,000 Sweepstakes$PO Box 1000000$Anytown, CA 12345$USA",
+            Utils.encodePostalAddress( "$1,000,000 Sweepstakes\nPO Box 1000000\nAnytown, CA 12345\nUSA", "\n" ) );
     }
 }

--- a/plugins/valueeditors/src/main/java/org/apache/directory/studio/valueeditors/address/AddressDialog.java
+++ b/plugins/valueeditors/src/main/java/org/apache/directory/studio/valueeditors/address/AddressDialog.java
@@ -22,6 +22,7 @@ package org.apache.directory.studio.valueeditors.address;
 
 
 import org.apache.directory.studio.ldapbrowser.core.BrowserCoreConstants;
+import org.apache.directory.studio.ldapbrowser.core.utils.Utils;
 import org.apache.directory.studio.valueeditors.ValueEditorsActivator;
 import org.apache.directory.studio.valueeditors.ValueEditorsConstants;
 import org.eclipse.jface.dialogs.Dialog;
@@ -93,10 +94,7 @@ public class AddressDialog extends Dialog
      */
     protected void okPressed()
     {
-        returnAddress = text.getText();
-        returnAddress = returnAddress.replaceAll( "\n", "\\$" ); //$NON-NLS-1$ //$NON-NLS-2$
-        returnAddress = returnAddress.replaceAll( "\r", "\\$" ); //$NON-NLS-1$ //$NON-NLS-2$
-        returnAddress = returnAddress.replaceAll( "\\$\\$", "\\$" ); //$NON-NLS-1$ //$NON-NLS-2$
+        returnAddress = Utils.encodePostalAddress( text.getText(), BrowserCoreConstants.LINE_SEPARATOR );
         super.okPressed();
     }
 
@@ -113,7 +111,7 @@ public class AddressDialog extends Dialog
 
         // text widget
         text = new Text( composite, SWT.MULTI | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL );
-        text.setText( initialAddress.replaceAll( "\\$", BrowserCoreConstants.LINE_SEPARATOR ) ); //$NON-NLS-1$
+        text.setText( Utils.decodePostalAddress( initialAddress, BrowserCoreConstants.LINE_SEPARATOR ) );
         // GridData gd = new GridData(GridData.GRAB_HORIZONTAL |
         // GridData.HORIZONTAL_ALIGN_FILL);
         gd = new GridData( GridData.FILL_BOTH );

--- a/plugins/valueeditors/src/main/java/org/apache/directory/studio/valueeditors/address/AddressValueEditor.java
+++ b/plugins/valueeditors/src/main/java/org/apache/directory/studio/valueeditors/address/AddressValueEditor.java
@@ -22,6 +22,7 @@ package org.apache.directory.studio.valueeditors.address;
 
 
 import org.apache.directory.studio.ldapbrowser.core.model.IValue;
+import org.apache.directory.studio.ldapbrowser.core.utils.Utils;
 import org.apache.directory.studio.valueeditors.AbstractDialogStringValueEditor;
 import org.eclipse.swt.widgets.Shell;
 
@@ -72,7 +73,7 @@ public class AddressValueEditor extends AbstractDialogStringValueEditor
 
         if ( !showRawValues() )
         {
-            displayValue = displayValue.replaceAll( "\\$", ", " ); //$NON-NLS-1$ //$NON-NLS-2$
+            displayValue = Utils.decodePostalAddress( displayValue, ", " ); //$NON-NLS-1$
         }
 
         return displayValue;

--- a/tests/test.integration.ui/src/main/java/org/apache/directory/studio/test/integration/ui/ValueEditorTest.java
+++ b/tests/test.integration.ui/src/main/java/org/apache/directory/studio/test/integration/ui/ValueEditorTest.java
@@ -42,6 +42,7 @@ import org.apache.directory.studio.valueeditors.HexValueEditor;
 import org.apache.directory.studio.valueeditors.IValueEditor;
 import org.apache.directory.studio.valueeditors.InPlaceTextValueEditor;
 import org.apache.directory.studio.valueeditors.TextValueEditor;
+import org.apache.directory.studio.valueeditors.address.AddressValueEditor;
 import org.apache.directory.studio.valueeditors.bool.InPlaceBooleanValueEditor;
 import org.apache.directory.studio.valueeditors.oid.InPlaceOidValueEditor;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,6 +59,7 @@ public class ValueEditorTest extends AbstractTestBase
 {
 
     private static final String CN = "cn";
+    private static final String POSTAL = "postalAddress";
     private static final String USER_PWD = "userPassword";
 
     private static final String EMPTY_STRING = "";
@@ -75,6 +77,9 @@ public class ValueEditorTest extends AbstractTestBase
 
     private static final String NUMERIC_OID = "1.3.6.1.4.1.1466.20037";
     private static final String DESCR_OID = "a-zA-Z0-9";
+
+    private static final String ADDRESS_DISPLAY = "$1,000,000 Sweepstakes, PO Box 1000000, Anytown, CA 12345, USA";
+    private static final String ADDRESS_RAW = "\\241,000,000 Sweepstakes$PO Box 1000000$Anytown, CA 12345$USA";
 
     public static Stream<Arguments> data()
     {
@@ -329,6 +334,16 @@ public class ValueEditorTest extends AbstractTestBase
                     Data.data().valueEditorClass( HexValueEditor.class ).attribute( USER_PWD ).rawValue( PNG )
                         .expectedRawValue( PNG ).expectedDisplayValue( "Binary Data (4 Bytes)" )
                         .expectedHasValue( true ).expectedStringOrBinaryValue( PNG ) },
+
+                /*
+                 * AddressValueEditor can handle a multi-line postal address with escaped characters.
+                 */
+
+                {
+                    "AddressValueEditor - RFC example",
+                    Data.data().valueEditorClass( AddressValueEditor.class ).attribute( POSTAL ).rawValue( ADDRESS_RAW )
+                        .expectedRawValue( ADDRESS_RAW ).expectedDisplayValue( ADDRESS_DISPLAY )
+                        .expectedHasValue( true ).expectedStringOrBinaryValue( ADDRESS_RAW ) },
             } ).map( d -> Arguments.arguments( ( String ) d[0], ( Data ) d[1] ) );
     }
 


### PR DESCRIPTION
This builds on the changes made for DIRSTUDIO-1296 to give the value editor complete and correct en-/decoding of the RFC 4517 Postal Address syntax.