### PR TITLE
Update .desktop file

### DIFF
--- a/tools/Debian Package/package/usr/share/applications/apachedirectorystudio.desktop
+++ b/tools/Debian Package/package/usr/share/applications/apachedirectorystudio.desktop
@@ -1,9 +1,8 @@
 [Desktop Entry]
 Version=1.0
-Encoding=UTF-8
 Name=Apache Directory Studio
 GenericName=Apache Directory Studio
 Comment=LDAP Browser and Directory Client
 Type=Application
 Exec=apachedirectorystudio
-Categories=Accessories;
+Categories=Development;Database;


### PR DESCRIPTION
Remove the deprecated `Encoding` key [1]
Use registered categories [2].

[1] https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#deprecated-items
[2] https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html#category-registry