### PR TITLE
DIRSTUDIO-1293 | Changes for native Apple Silicon M1 build

### DIFF
--- a/eclipse-trgt-platform/template/org.apache.directory.studio.eclipse-trgt-platform.template
+++ b/eclipse-trgt-platform/template/org.apache.directory.studio.eclipse-trgt-platform.template
@@ -110,17 +110,17 @@
     </location>
 
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.rcp.feature.group" version="4.18.0.v20201202-1800"/>
-      <unit id="org.eclipse.rcp.source.feature.group" version="4.18.0.v20201202-1800"/>
-      <unit id="org.eclipse.platform.feature.group" version="4.18.0.v20201202-1800"/>
-      <unit id="org.eclipse.platform.source.feature.group" version="4.18.0.v20201202-1800"/>
-      <unit id="org.eclipse.jdt.feature.group" version="3.18.600.v20201202-1800"/>
-      <unit id="org.eclipse.jdt.source.feature.group" version="3.18.600.v20201202-1800"/>
-      <unit id="org.eclipse.pde.feature.group" version="3.14.600.v20201202-1800"/>
-      <unit id="org.eclipse.pde.source.feature.group" version="3.14.600.v20201202-1800"/>
-      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.4.1000.v20201106-1246"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.1000.v20200915-1508"/>
-      <repository location="http://download.eclipse.org/eclipse/updates/4.18"/>
+      <unit id="org.eclipse.rcp.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.rcp.source.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.platform.source.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.pde.source.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.22/R-4.22-202111241800"/>
     </location>
 
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,12 @@
               <ws>cocoa</ws>
               <arch>x86_64</arch>
             </environment>
+
+            <environment>
+              <os>macosx</os>
+              <ws>cocoa</ws>
+              <arch>aarch64</arch>
+            </environment>
           </environments>
         </configuration>
       </plugin>


### PR DESCRIPTION
I'm not sure about these Eclipse targets and version numbers in general, but I've used the same approach for another [project](https://www.eclipse.org/mat) ) as I really need the tools and don't want to install Rosetta.

But with that change I'm able to build and use it without Rosetta :)

