### PR TITLE
DIRSTUDIO-1309: Upgrade to Eclipse 4.24

### DIFF
--- a/eclipse-trgt-platform/template/org.apache.directory.studio.eclipse-trgt-platform.template
+++ b/eclipse-trgt-platform/template/org.apache.directory.studio.eclipse-trgt-platform.template
@@ -111,17 +111,17 @@
     </location>
 
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.rcp.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.rcp.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.platform.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.pde.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/eclipse/updates/4.22/R-4.22-202111241800"/>
+      <unit id="org.eclipse.rcp.feature.group" version="4.24.0.v20220607-0700"/>
+      <unit id="org.eclipse.rcp.source.feature.group" version="4.24.0.v20220607-0700"/>
+      <unit id="org.eclipse.platform.feature.group" version="4.24.0.v20220607-0700"/>
+      <unit id="org.eclipse.platform.source.feature.group" version="4.24.0.v20220607-0700"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.18.1200.v20220607-0700"/>
+      <unit id="org.eclipse.jdt.source.feature.group" version="3.18.1200.v20220607-0700"/>
+      <unit id="org.eclipse.pde.feature.group" version="3.14.1200.v20220607-0700"/>
+      <unit id="org.eclipse.pde.source.feature.group" version="3.14.1200.v20220607-0700"/>
+      <unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.4.1600.v20220518-1326"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.1700.v20220509-0833"/>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.24"/>
     </location>
 
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
This is an alternate version of PR #36 in case the maintainers would prefer to keep using explicit version numbers here.

All unit tests (including `-Denable-ui-tests`) pass. Also tested manually on an M1 Mac with macOS _Ventura 13.3.1 (a)_.

Eclipse 4.24 is chosen because it's the newest version to which these libraries can be upgraded without having to make any other changes. Eclipse 4.25 causes a dependency error with JUnit (which eventually will need to be resolved, but isn't anything that needs to be done in order to resolve the Apple silicon issue).