### PR TITLE
Add dependabot.yaml for automatic dep updates lookup

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Yesterday I tried figuring out the Apple silicon build.  I worked a bit against this project.  Noticed that some deps was out of date.  In my own fork, I added `.github/dependabot.yaml` to look both GitHub Actions and Maven deps.

Not sure if this need to be activated extra.  I see that Dependabot has opened some already, but I'm not sure that it uses the newer version of Dependabot.  This would have created #42 automatically.