### PR TITLE
DIRSTUDIO-1333 correcting typo

### DIFF
--- a/plugins/ldapbrowser.common/src/main/resources/valueEditors.exsd
+++ b/plugins/ldapbrowser.common/src/main/resources/valueEditors.exsd
@@ -143,7 +143,7 @@
     &lt;valueEditor
           name=&quot;Text Editor&quot;
           icon=&quot;resources/icons/texteditor.gif&quot;
-          class=&quot;oorg.apache.directory.studio.valueeditors.TextValueEditor&quot;
+          class=&quot;org.apache.directory.studio.valueeditors.TextValueEditor&quot;
           /&gt;
    &lt;/extension&gt;         
 &lt;/pre&gt;


### PR DESCRIPTION
The valueEditor reference in valueEditors.exsd contains a typo in the class name: oorg.apache.directory.studio.valueeditors.TextValueEditor

modified: valueEditors.exsd