### PR TITLE
Studio 2.0 rc1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,5 +17,33 @@
 # under the License.
 
 # This script do a full build of Studio (including the MANIFEST generation and the P2 local repository construction)
-mvn -f pom-first.xml clean install -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 
-mvn clean install -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.entityExpansionLimit=0
+
+# Building requires Java 25 or 17
+if [ uname -o =="Darwin" ]; then
+    if /usr/libexec/java_home -v 25 -a $(uname -m) -F 2>/dev/null; then
+        export JAVA_HOME=$(/usr/libexec/java_home -v 25 -a $(uname -m) -F | head -n1)
+    elif /usr/libexec/java_home -v 17 -a $(uname -m) -F 2>/dev/null; then
+        export JAVA_HOME=$(/usr/libexec/java_home -v 17 -a $(uname -m) -F | head -n1)
+    else
+        echo "Native JDK 25 or 17 not found, trying to build with default JDK..."
+    fi 
+fi
+
+mvn -f pom-first.xml clean install 
+mvn -f pom.xml clean install -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.entityExpansionLimit=0
+
+if [[ $1 =~ --datestamp ]] ; then
+    for f in product/target/products/ApacheDirectoryStudio-*-SNAPSHOT-*; do 
+        mv -v $f ${f/-SNAPSHOT/.v$(date +%Y%m%d)}; 
+    done
+fi
+
+# build disk images for macOS
+cd installers/macos/src/dmg/
+# This creates unsigned DMGs, users might have to approve running/installing Studio
+# add --sign <key> to codesign the app bundles
+./createDMG.sh
+cd -
+
+# print build artifacts
+ls -l product/target/products/ApacheDirectoryStudio-*

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,12 @@
             </environment>
 
             <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>aarch64</arch>
+            </environment>  
+
+            <environment>
               <os>win32</os>
               <ws>win32</ws>
               <arch>x86_64</arch>


### PR DESCRIPTION
As discussed on https://lists.apache.org/thread/ldtllt26v0f450yq881g4lo55kqxq43h

Builds with JDK 17 and 25 and produces the following artefacts:

ApacheDirectoryStudio-2.0.0-SNAPSHOT-linux.gtk.aarch64.tar.gz
ApacheDirectoryStudio-2.0.0-SNAPSHOT-linux.gtk.x86_64.tar.gz
ApacheDirectoryStudio-2.0.0-SNAPSHOT-macosx.cocoa.aarch64.dmg
ApacheDirectoryStudio-2.0.0-SNAPSHOT-macosx.cocoa.aarch64.tar.gz
ApacheDirectoryStudio-2.0.0-SNAPSHOT-macosx.cocoa.x86_64.dmg
ApacheDirectoryStudio-2.0.0-SNAPSHOT-macosx.cocoa.x86_64.tar.gz
ApacheDirectoryStudio-2.0.0-SNAPSHOT-win32.win32.x86_64.zip

